### PR TITLE
Adds --announce, -a option to create

### DIFF
--- a/docs/create.txt
+++ b/docs/create.txt
@@ -3,3 +3,5 @@ Usage: torrent-docker create [image-name]
   Creates a new torrent from an docker image.
   The torrent file will be saved in ./image-name.torrent
   and the torrent content will be stored in ./image-name/
+
+  --announce-list, -a  List of trackers for the torrent (comma separated)


### PR DESCRIPTION
This enables the option to set a tracker for the torrent explicitly upon
creation.

The use case here is when you you'd like to use e.g. a private tracker instead of the public ones.
